### PR TITLE
Update fppLCD to use new /home/fpp directory

### DIFF
--- a/scripts/lcd/fppLCD.py
+++ b/scripts/lcd/fppLCD.py
@@ -126,6 +126,11 @@ class fppLCD():
                           "Timeout         ")
 
   def Initialize(self):
+
+    if os.path.exists("/home/fpp/media"):
+      self.PLAYLIST_DIRECTORY = "/home/fpp/media/playlists/";
+      self.SETTINGS_FILE = "/home/fpp/media/settings";
+
     strColorIndex = self.readSetting("piLCD_BackColor")
     if strColorIndex.isdigit():
       self.BackgroundColor = int(strColorIndex);

--- a/scripts/lcd/fppLCD.py
+++ b/scripts/lcd/fppLCD.py
@@ -20,9 +20,13 @@ class fppLCD():
     self.THIS_DIRECTORY = directory
 
     self.BACK_COLOR = 0
+	#Directory locations
     self.PLAYLIST_DIRECTORY = "/home/pi/media/playlists/"
     self.SETTINGS_FILE = "/home/pi/media/settings"
-
+	#Alternate location
+	self.PLAYLIST_DIR_ALT = "/home/fpp/media/playlists/"
+    self.SETTINGS_DIR_ALT= "/home/fpp/media/settings"
+	
     self.DIRECTION_LEFT = 0
     self.DIRECTION_RIGHT = 1
     self.MAX_CHARS = 16
@@ -126,10 +130,10 @@ class fppLCD():
                           "Timeout         ")
 
   def Initialize(self):
-
+	#Check the new fpp user directory exists
     if os.path.exists("/home/fpp/media"):
-      self.PLAYLIST_DIRECTORY = "/home/fpp/media/playlists/";
-      self.SETTINGS_FILE = "/home/fpp/media/settings";
+      self.PLAYLIST_DIRECTORY = self.PLAYLIST_DIR_ALT;
+      self.SETTINGS_FILE = self.SETTINGS_DIR_ALT;
 
     strColorIndex = self.readSetting("piLCD_BackColor")
     if strColorIndex.isdigit():


### PR DESCRIPTION
The current script doesn't work if you use the 'FPP 2.0 install script'
to build FPP install (I have a RPi 2), and this is because the LCD
settings path for self.PLAYLIST_DIRECTORY and self.SETTINGS_FILE is
hardcoded to '/home/pi/media'

I added a little check at init to use '/home/fpp/media' if it exists,
otherwise it will just use the default value of already set in the
script.
